### PR TITLE
refine grammar rules in parser.py for improved parsing accuracy

### DIFF
--- a/Project6/parser/parser.py
+++ b/Project6/parser/parser.py
@@ -20,10 +20,10 @@ V -> "smiled" | "tell" | "were"
 """
 
 NONTERMINALS = """
-S -> NP VP
-NP -> Det N | Det Adj N | Det Adj Adj N | N | NP PP
-VP -> V | V NP | V NP PP | VP Conj VP
-PP -> P NP
+S -> NP VP | S Conj S
+NP -> N | Det NP | Adj NP | NP PP | Adj N | Det Adj N | P N
+VP -> V | V NP | VP PP | Adv VP | VP Adv | VP Conj VP | V N | V P NP
+PP -> P NP | P Det N | P N | P Det Adj N | P Art Adj N
 """
 
 grammar = nltk.CFG.fromstring(NONTERMINALS + TERMINALS)


### PR DESCRIPTION
기존 코드는 sentences 폴더에 있는 텍스트 중 파싱하지 못하는 텍스트가 있습니다
모든 텍스트를 파싱할 수 있게 문법을 추가하였습니다